### PR TITLE
MER-5: wire merc-alpha named Firebase app (mercAuth, mercDb)

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -42,11 +42,11 @@ time. Wait for explicit confirmation before writing code.
 **Step 5 — Cut the branch**
 
 ```bash
-git show-ref --verify --quiet refs/heads/merc || git branch merc main   # create integration branch once
-git switch merc && git switch -c mer-<n>                                 # <n> = ticket number, e.g. mer-6
+git switch main && git switch -c mer-<n>   # <n> = ticket number, e.g. mer-6 — cut directly from main
 ```
 
-Keep it local — do not push unless explicitly told.
+There is no `merc` integration branch. **Never push and never open PRs** — the user handles
+all pushing and PR creation; the branch's PR merges directly into `main`.
 
 **Step 6 — Implement**
 
@@ -55,6 +55,11 @@ Keep it local — do not push unless explicitly told.
   append-only ledger, `onSnapshot` scoped queries.
 - Match surrounding BlueFire patterns; Vuetify layouts over custom divs (no div-itis).
 - Tag deferred / problem lines `// TODO: MER-<n>: <note>` (Merc uses MER-, not TG-).
+- **Checkpoint commits:** commit at meaningful stages — a coherent sub-step that leaves the
+  app working — not every file change, so we can backtrack. Subjects short and poignant,
+  prefixed with the ticket ID: `MER-<n>: <what changed>` (e.g. `MER-6: scaffold shell + /merc route`).
+  This is standing authorization within a `/build` run — commit without stopping to ask.
+  **Local commits only — never push.** End each message with the standard `Co-Authored-By` trailer.
 
 **Step 7 — Verify acceptance criteria**
 
@@ -66,7 +71,7 @@ until the project and config exist — do not report them as passing.
 
 - Summarize: what was built, which criteria pass, which are pending-live, and anything
   flagged in Step 3.
-- Leave the branch for review; do not merge into `merc` without sign-off.
+- Leave the branch local for review; the user pushes it and opens the PR into `main` — never push or merge yourself.
 - Update the local memory file with anything learned this session.
 
 ## Hard stops (never do these)

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "bluefire-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 8080
+    }
+  ]
+}

--- a/merc.md
+++ b/merc.md
@@ -46,9 +46,11 @@ On top of the root stack (Vue 3.5 `<script setup>`, Vite, Pinia, Vuetify 4, no T
 
 ## Git workflow (Merc)
 
-- Long-lived integration branch `merc`, cut from `main`. Each ticket gets a branch
-  `mer-<n>` (lowercase) cut from `merc`. Branches stay **local — do not push** unless told.
-  Do not merge a ticket branch into `merc` without sign-off.
+- **No long-lived `merc` integration branch.** Merc ships into BlueFire like any other
+  module: each ticket gets a branch `mer-<n>` (lowercase) cut **directly from `main`**, and
+  its PR merges **directly into `main`**.
+- **Claude never pushes and never opens PRs.** All pushing and PR creation are the user's;
+  branches stay local on Claude's side until the user pushes them.
 
 ## Tagging
 

--- a/src/config/mercFirebaseConfig.js
+++ b/src/config/mercFirebaseConfig.js
@@ -1,0 +1,12 @@
+// Merc (merc-alpha) Firebase web config — a separate Firebase project from BlueFire (ADR-005).
+// API key + identifiers are read from import.meta.env (real values live in the gitignored
+// .env.local), mirroring src/plugins/firebase.js. projectId/storageBucket are non-sensitive
+// public identifiers, so they're inlined.
+export const mercFirebaseConfig = {
+  apiKey: import.meta.env.VITE_MERC_API_KEY,
+  authDomain: import.meta.env.VITE_MERC_AUTH_DOMAIN,
+  projectId: 'merc-alpha',
+  storageBucket: 'merc-alpha.firebasestorage.app',
+  messagingSenderId: import.meta.env.VITE_MERC_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_MERC_APP_ID
+}

--- a/src/plugins/mercFirebase.js
+++ b/src/plugins/mercFirebase.js
@@ -1,0 +1,13 @@
+// Merc's dedicated Firebase app — initialized as a NAMED secondary app ('merc') so it stays
+// fully separate from BlueFire's default app (ADR-005). Every Merc getAuth/getFirestore must
+// use these exports — never BlueFire's src/plugins/firebase.js or userStore.
+import { initializeApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
+import { mercFirebaseConfig } from '@/config/mercFirebaseConfig'
+
+const mercApp = initializeApp(mercFirebaseConfig, 'merc')
+
+export const mercAuth = getAuth(mercApp)
+export const mercDb = getFirestore(mercApp)
+export { mercApp }


### PR DESCRIPTION
Named secondary app initialized via initializeApp(mercConfig, 'merc'), separate from BlueFire's default app (ADR-005). Config reads from import.meta.env (VITE_MERC_*) in gitignored .env.local.