### PR TITLE
MER-26: Merc first-load fly-to + landing polish

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,8 @@
 <template>
   <v-app>
-    <main-app-header v-if="!isMercShell" />
+    <main-app-header v-if="!isMercApp" />
     <v-main>
-      <v-pull-to-refresh v-if="isNative && !isMercShell" @load="refreshApp" :pull-down-threshold="PULL_TO_REFRESH_THRESHOLD_PX">
+      <v-pull-to-refresh v-if="isNative && !isMercApp" @load="refreshApp" :pull-down-threshold="PULL_TO_REFRESH_THRESHOLD_PX">
         <template #pullDownPanel>
           <v-row class="mt-3">
             <v-col class="text-center" col="3">
@@ -22,7 +22,7 @@
         <router-view />
       </v-container>
     </v-main>
-    <mobile-bottom-navigation-menu v-if="!isMercShell" />
+    <mobile-bottom-navigation-menu v-if="!isMercApp" />
     <toast-notification-stack />
   </v-app>
 </template>
@@ -41,7 +41,7 @@ const route = useRoute()
 const isNative = Capacitor.isNativePlatform()
 
 // On the Merc shell (/merc/app), BlueFire's chrome hands off to Merc's own top bar + bottom nav.
-const isMercShell = computed(() => route.path.startsWith('/merc/app'))
+const isMercApp = computed(() => route.path.startsWith('/merc/app'))
 
 async function refreshApp({ done }) {
   try {

--- a/src/components/merc/MercBottomNav.vue
+++ b/src/components/merc/MercBottomNav.vue
@@ -1,13 +1,13 @@
 <template>
   <!-- Merc shell bottom nav: Map / Showings / (+) / Wallet / Me. The center + is a raised FAB.
-       Talks to the shell store directly (no emit bubbling). Height mirrors BlueFire's bottom-nav
+       Talks to the layout store directly (no emit bubbling). Height mirrors BlueFire's bottom-nav
        shim (extra height on native for the gesture inset). -->
   <v-sheet color="surface" elevation="10" class="merc-bottom-nav border-t-sm" :height="navHeight">
     <v-row no-gutters align="center" class="fill-height">
       <v-col v-for="item in leftItems" :key="item.key" class="text-center">
         <v-btn
-          @click="shell.select(item.key)"
-          :color="shell.navSelection === item.key ? 'primary' : 'medium-emphasis'"
+          @click="mercLayoutStore.select(item.key)"
+          :color="mercLayoutStore.navSelection === item.key ? 'primary' : 'medium-emphasis'"
           variant="text"
           stacked
           size="small"
@@ -22,7 +22,7 @@
 
       <v-col cols="auto" class="text-center px-2">
         <v-btn
-          @click="shell.openPost()"
+          @click="mercLayoutStore.openPost()"
           icon="mdi-plus"
           color="secondary"
           size="x-large"
@@ -33,8 +33,8 @@
 
       <v-col v-for="item in rightItems" :key="item.key" class="text-center">
         <v-btn
-          @click="shell.select(item.key)"
-          :color="shell.navSelection === item.key ? 'primary' : 'medium-emphasis'"
+          @click="mercLayoutStore.select(item.key)"
+          :color="mercLayoutStore.navSelection === item.key ? 'primary' : 'medium-emphasis'"
           variant="text"
           stacked
           size="small"
@@ -52,10 +52,10 @@
 
 <script setup>
 import { Capacitor } from '@capacitor/core'
-import { useMercShellStore } from '@/stores/mercShellStore'
+import { useMercLayoutStore } from '@/stores/mercLayoutStore'
 import { MERC_BOTTOM_NAV_HEIGHT, MERC_BOTTOM_NAV_HEIGHT_NATIVE } from '@/configs/mercDefaults'
 
-const shell = useMercShellStore()
+const mercLayoutStore = useMercLayoutStore()
 const navHeight = Capacitor.isNativePlatform() ? MERC_BOTTOM_NAV_HEIGHT_NATIVE : MERC_BOTTOM_NAV_HEIGHT
 
 const leftItems = [

--- a/src/components/merc/MercListingFlow.vue
+++ b/src/components/merc/MercListingFlow.vue
@@ -1,0 +1,74 @@
+<template>
+  <!-- "How a listing works" — compact 3-step flow: icons side by side with arrows between, so it
+       reads the same on mobile and desktop (no stacking). List/Claim are Merc blue, Profit is the
+       green payout ($). Claim's map uses currentColor for its neutral lines so it adapts to theme. -->
+  <section class="text-center mx-auto merc-listing-flow">
+    <!--    <p class="text-overline text-medium-emphasis mb-3">
+      How it works
+    </p>-->
+
+    <v-row align="start" justify="center" no-gutters class="flex-nowrap">
+      <!-- 1 — list -->
+      <v-col class="merc-flow-step text-center">
+        <v-icon icon="mdi-map-marker" size="72" color="#3b82f6" />
+        <p class="text-caption text-medium-emphasis mt-1 mb-0">
+          List
+        </p>
+      </v-col>
+
+      <v-col cols="auto" class="merc-flow-arrow">
+        <v-icon icon="mdi-arrow-right" size="22" color="medium-emphasis" />
+      </v-col>
+
+      <!-- 2 — claim -->
+      <v-col class="merc-flow-step text-center">
+        <svg class="merc-flow-icon" viewBox="0 0 72 72" role="img" aria-label="Claim">
+          <rect x="8" y="16" width="56" height="40" rx="8" fill="none" stroke="currentColor" stroke-opacity="0.22" stroke-width="1.5" />
+          <path d="M26 16V56M46 16V56M8 36H64" fill="none" stroke="currentColor" stroke-opacity="0.14" stroke-width="1" />
+          <circle cx="18" cy="45" r="3" fill="currentColor" opacity="0.4" />
+          <circle cx="55" cy="26" r="3" fill="currentColor" opacity="0.4" />
+          <circle cx="36" cy="36" r="12" fill="#3b82f6" opacity="0.18" />
+          <circle cx="36" cy="36" r="5.5" fill="#3b82f6" />
+        </svg>
+        <p class="text-caption text-medium-emphasis mt-1 mb-0">
+          Claim
+        </p>
+      </v-col>
+
+      <v-col cols="auto" class="merc-flow-arrow">
+        <v-icon icon="mdi-arrow-right" size="22" color="medium-emphasis" />
+      </v-col>
+
+      <!-- 3 — profit -->
+      <v-col class="merc-flow-step text-center">
+        <v-icon icon="mdi-currency-usd" size="72" color="#22c55e" />
+        <p class="text-caption text-medium-emphasis mt-1 mb-0">
+          Profit
+        </p>
+      </v-col>
+    </v-row>
+  </section>
+</template>
+
+<script setup>
+// Static presentational component (MER-26 landing polish) — no props or state yet.
+</script>
+
+<style scoped>
+/* Keep the flow tidy and centered on wide screens; fills the width on mobile. */
+.merc-listing-flow {
+  max-width: 520px;
+}
+
+.merc-flow-icon {
+  display: block;
+  width: 72px;
+  height: 72px;
+  margin: 0 auto;
+}
+
+/* Sit the arrow at the icons' vertical center (icon is 72px tall, arrow ~22px). */
+.merc-flow-arrow {
+  margin-top: 25px;
+}
+</style>

--- a/src/components/merc/MercMapCanvas.vue
+++ b/src/components/merc/MercMapCanvas.vue
@@ -7,7 +7,7 @@
 <script setup>
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { ref, onMounted, onUnmounted } from 'vue'
-import { useMercShellStore } from '@/stores/mercShellStore'
+import { useMercLayoutStore } from '@/stores/mercLayoutStore'
 import {
   MERC_MAP_DEFAULT_CENTER,
   MERC_MAP_DEFAULT_ZOOM,
@@ -17,7 +17,7 @@ import {
   MERC_MAP_INTRO_CURVE
 } from '@/configs/mercDefaults'
 
-const shell = useMercShellStore()
+const mercLayoutStore = useMercLayoutStore()
 const mapContainer = ref(null)
 let map = null
 let resizeObserver = null
@@ -40,7 +40,7 @@ onMounted(async () => {
   // unless the user disabled it (Profile toggle) or prefers reduced motion. When not playing we
   // just construct at the normal zoom, so the static view is indistinguishable.
   const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
-  const playIntro = shell.introEnabled && !reduceMotion
+  const playIntro = mercLayoutStore.introEnabled && !reduceMotion
 
   mapboxgl.accessToken = token
   map = new mapboxgl.Map({

--- a/src/components/merc/MercMapCanvas.vue
+++ b/src/components/merc/MercMapCanvas.vue
@@ -7,8 +7,17 @@
 <script setup>
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { ref, onMounted, onUnmounted } from 'vue'
-import { MERC_MAP_DEFAULT_CENTER, MERC_MAP_DEFAULT_ZOOM, MERC_MAP_STYLE } from '@/configs/mercDefaults'
+import { useMercShellStore } from '@/stores/mercShellStore'
+import {
+  MERC_MAP_DEFAULT_CENTER,
+  MERC_MAP_DEFAULT_ZOOM,
+  MERC_MAP_STYLE,
+  MERC_MAP_INTRO_START_ZOOM,
+  MERC_MAP_INTRO_DURATION_MS,
+  MERC_MAP_INTRO_CURVE
+} from '@/configs/mercDefaults'
 
+const shell = useMercShellStore()
 const mapContainer = ref(null)
 let map = null
 let resizeObserver = null
@@ -27,12 +36,18 @@ onMounted(async () => {
   const { default: mapboxgl } = await import('mapbox-gl')
   if (destroyed || !mapContainer.value) return // component unmounted while the lib loaded
 
+  // First-load cinematic fly-to (MER-26): start wide and sweep in — but only on the first entry
+  // this session, only if the user hasn't disabled it, and never under prefers-reduced-motion.
+  // When not playing we just construct at the normal zoom, so the static view is indistinguishable.
+  const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+  const playIntro = shell.shouldPlayIntro && !reduceMotion
+
   mapboxgl.accessToken = token
   map = new mapboxgl.Map({
     container: mapContainer.value,
     style: `${MERC_MAP_STYLE}?optimize=true`, // style-optimized vector tiles (drops unused layers)
     center: [MERC_MAP_DEFAULT_CENTER.lng, MERC_MAP_DEFAULT_CENTER.lat], // Mapbox is [lng, lat]
-    zoom: MERC_MAP_DEFAULT_ZOOM,
+    zoom: playIntro ? MERC_MAP_INTRO_START_ZOOM : MERC_MAP_DEFAULT_ZOOM,
     // (i) attribution control removed per request. ⚠️ Mapbox ToS requires attribution — re-add
     // (or surface it elsewhere) before production. The Mapbox wordmark logo stays.
     attributionControl: false
@@ -41,7 +56,21 @@ onMounted(async () => {
   // In a flex/fixed layout — and especially the Capacitor WebView — the container can reach its
   // real size AFTER init; without a resize the map renders the whole world zoomed out and stays
   // there. Keep it sized to its container. (Mapbox equivalent of Leaflet's invalidateSize.)
-  map.on('load', () => map && map.resize())
+  map.on('load', () => {
+    if (!map) return
+    map.resize()
+    if (playIntro) {
+      // Flag before flying so navigating away mid-flight and back this session won't replay it.
+      shell.markIntroPlayed()
+      map.flyTo({
+        center: [MERC_MAP_DEFAULT_CENTER.lng, MERC_MAP_DEFAULT_CENTER.lat],
+        zoom: MERC_MAP_DEFAULT_ZOOM,
+        duration: MERC_MAP_INTRO_DURATION_MS,
+        curve: MERC_MAP_INTRO_CURVE,
+        essential: true // we already gate reduced-motion above; keep GL from second-guessing the animation
+      })
+    }
+  })
   if (window.ResizeObserver) {
     resizeObserver = new ResizeObserver(() => map && map.resize())
     resizeObserver.observe(mapContainer.value)

--- a/src/components/merc/MercMapCanvas.vue
+++ b/src/components/merc/MercMapCanvas.vue
@@ -36,11 +36,11 @@ onMounted(async () => {
   const { default: mapboxgl } = await import('mapbox-gl')
   if (destroyed || !mapContainer.value) return // component unmounted while the lib loaded
 
-  // First-load cinematic fly-to (MER-26): start wide and sweep in — but only on the first entry
-  // this session, only if the user hasn't disabled it, and never under prefers-reduced-motion.
-  // When not playing we just construct at the normal zoom, so the static view is indistinguishable.
+  // First-load cinematic fly-to (MER-26): start at a global view and sweep in on every entry —
+  // unless the user disabled it (Profile toggle) or prefers reduced motion. When not playing we
+  // just construct at the normal zoom, so the static view is indistinguishable.
   const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
-  const playIntro = shell.shouldPlayIntro && !reduceMotion
+  const playIntro = shell.introEnabled && !reduceMotion
 
   mapboxgl.accessToken = token
   map = new mapboxgl.Map({
@@ -60,8 +60,6 @@ onMounted(async () => {
     if (!map) return
     map.resize()
     if (playIntro) {
-      // Flag before flying so navigating away mid-flight and back this session won't replay it.
-      shell.markIntroPlayed()
       map.flyTo({
         center: [MERC_MAP_DEFAULT_CENTER.lng, MERC_MAP_DEFAULT_CENTER.lat],
         zoom: MERC_MAP_DEFAULT_ZOOM,

--- a/src/components/merc/MercProfileSheet.vue
+++ b/src/components/merc/MercProfileSheet.vue
@@ -33,7 +33,7 @@
         <v-list-item prepend-icon="mdi-theme-light-dark" title="Appearance" subtitle="Dark mode toggle — MER-25" />
         <v-list-item prepend-icon="mdi-airplane-takeoff" title="Intro animation" subtitle="Cinematic zoom on entry">
           <template #append>
-            <v-switch v-model="shell.introEnabled" color="primary" density="compact" hide-details inset />
+            <v-switch v-model="mercLayoutStore.introEnabled" color="primary" density="compact" hide-details inset />
           </template>
         </v-list-item>
         <v-list-item prepend-icon="mdi-help-circle-outline" title="Help & feedback" />
@@ -59,11 +59,11 @@
 <script setup>
 import { computed } from 'vue'
 import { useMercAuthStore } from '@/stores/mercAuthStore'
-import { useMercShellStore } from '@/stores/mercShellStore'
+import { useMercLayoutStore } from '@/stores/mercLayoutStore'
 
 const emit = defineEmits(['close'])
 const mercAuthStore = useMercAuthStore()
-const shell = useMercShellStore()
+const mercLayoutStore = useMercLayoutStore()
 
 const displayName = computed(() => mercAuthStore.getUserDisplayName || 'Merc agent')
 const email = computed(() => mercAuthStore.getUserEmail || 'Not signed in')

--- a/src/components/merc/MercProfileSheet.vue
+++ b/src/components/merc/MercProfileSheet.vue
@@ -31,6 +31,11 @@
         <v-list-item prepend-icon="mdi-office-building-outline" title="Brokerage" subtitle="Pearson Realty" />
         <v-list-item prepend-icon="mdi-bell-outline" title="Notifications" />
         <v-list-item prepend-icon="mdi-theme-light-dark" title="Appearance" subtitle="Dark mode toggle — MER-25" />
+        <v-list-item prepend-icon="mdi-airplane-takeoff" title="Intro animation" subtitle="Cinematic zoom on first open">
+          <template #append>
+            <v-switch v-model="shell.introEnabled" color="primary" density="compact" hide-details inset />
+          </template>
+        </v-list-item>
         <v-list-item prepend-icon="mdi-help-circle-outline" title="Help & feedback" />
       </v-list>
     </v-card-text>
@@ -54,9 +59,11 @@
 <script setup>
 import { computed } from 'vue'
 import { useMercAuthStore } from '@/stores/mercAuthStore'
+import { useMercShellStore } from '@/stores/mercShellStore'
 
 const emit = defineEmits(['close'])
 const mercAuthStore = useMercAuthStore()
+const shell = useMercShellStore()
 
 const displayName = computed(() => mercAuthStore.getUserDisplayName || 'Merc agent')
 const email = computed(() => mercAuthStore.getUserEmail || 'Not signed in')

--- a/src/components/merc/MercProfileSheet.vue
+++ b/src/components/merc/MercProfileSheet.vue
@@ -31,7 +31,7 @@
         <v-list-item prepend-icon="mdi-office-building-outline" title="Brokerage" subtitle="Pearson Realty" />
         <v-list-item prepend-icon="mdi-bell-outline" title="Notifications" />
         <v-list-item prepend-icon="mdi-theme-light-dark" title="Appearance" subtitle="Dark mode toggle — MER-25" />
-        <v-list-item prepend-icon="mdi-airplane-takeoff" title="Intro animation" subtitle="Cinematic zoom on first open">
+        <v-list-item prepend-icon="mdi-airplane-takeoff" title="Intro animation" subtitle="Cinematic zoom on entry">
           <template #append>
             <v-switch v-model="shell.introEnabled" color="primary" density="compact" hide-details inset />
           </template>

--- a/src/components/navigation/LandingPageCard.vue
+++ b/src/components/navigation/LandingPageCard.vue
@@ -20,7 +20,7 @@
           :key="chip"
           variant="outlined"
           density="compact"
-          class="text-grey"
+          :color="card.chipColor || 'grey'"
         >
           {{ chip }}
         </v-chip>

--- a/src/configs/mercDefaults.js
+++ b/src/configs/mercDefaults.js
@@ -11,10 +11,11 @@ export const MERC_MAP_DEFAULT_ZOOM = 11
 // Dark style to match the Merc shell. Swap freely (e.g. mapbox/standard for 3D).
 export const MERC_MAP_STYLE = 'mapbox://styles/mapbox/dark-v11'
 
-// First-load cinematic fly-to (MER-26). Open wide (regional) and sweep down into the market.
-// Gated to play once per session and skipped under prefers-reduced-motion — see mercShellStore.
-export const MERC_MAP_INTRO_START_ZOOM = 4.5
-export const MERC_MAP_INTRO_DURATION_MS = 3500
+// First-load cinematic fly-to (MER-26). Open at a global/hemisphere view (zoom 2 is where Mapbox's
+// globe projection shows) and sweep down into the market on every entry; skipped under
+// prefers-reduced-motion or when disabled — see mercShellStore.
+export const MERC_MAP_INTRO_START_ZOOM = 2
+export const MERC_MAP_INTRO_DURATION_MS = 4500
 export const MERC_MAP_INTRO_CURVE = 1.42 // flyTo zoom-out arc (Mapbox default; higher = more dramatic)
 
 // App shell (MER-9) — bottom nav heights. Mirrors BlueFire's MobileBottomNavigationMenu shim:

--- a/src/configs/mercDefaults.js
+++ b/src/configs/mercDefaults.js
@@ -11,6 +11,12 @@ export const MERC_MAP_DEFAULT_ZOOM = 11
 // Dark style to match the Merc shell. Swap freely (e.g. mapbox/standard for 3D).
 export const MERC_MAP_STYLE = 'mapbox://styles/mapbox/dark-v11'
 
+// First-load cinematic fly-to (MER-26). Open wide (regional) and sweep down into the market.
+// Gated to play once per session and skipped under prefers-reduced-motion — see mercShellStore.
+export const MERC_MAP_INTRO_START_ZOOM = 4.5
+export const MERC_MAP_INTRO_DURATION_MS = 3500
+export const MERC_MAP_INTRO_CURVE = 1.42 // flyTo zoom-out arc (Mapbox default; higher = more dramatic)
+
 // App shell (MER-9) — bottom nav heights. Mirrors BlueFire's MobileBottomNavigationMenu shim:
 // native gets extra height to clear the gesture inset.
 export const MERC_BOTTOM_NAV_HEIGHT = 64

--- a/src/configs/mercDefaults.js
+++ b/src/configs/mercDefaults.js
@@ -13,9 +13,9 @@ export const MERC_MAP_STYLE = 'mapbox://styles/mapbox/dark-v11'
 
 // First-load cinematic fly-to (MER-26). Open at a global/hemisphere view (zoom 2 is where Mapbox's
 // globe projection shows) and sweep down into the market on every entry; skipped under
-// prefers-reduced-motion or when disabled — see mercShellStore.
+// prefers-reduced-motion or when disabled — see mercLayoutStore.
 export const MERC_MAP_INTRO_START_ZOOM = 2
-export const MERC_MAP_INTRO_DURATION_MS = 14000
+export const MERC_MAP_INTRO_DURATION_MS = 4500
 export const MERC_MAP_INTRO_CURVE = 1.42 // flyTo zoom-out arc (Mapbox default; higher = more dramatic)
 
 // App shell (MER-9) — bottom nav heights. Mirrors BlueFire's MobileBottomNavigationMenu shim:

--- a/src/configs/mercDefaults.js
+++ b/src/configs/mercDefaults.js
@@ -15,7 +15,7 @@ export const MERC_MAP_STYLE = 'mapbox://styles/mapbox/dark-v11'
 // globe projection shows) and sweep down into the market on every entry; skipped under
 // prefers-reduced-motion or when disabled — see mercShellStore.
 export const MERC_MAP_INTRO_START_ZOOM = 2
-export const MERC_MAP_INTRO_DURATION_MS = 4500
+export const MERC_MAP_INTRO_DURATION_MS = 14000
 export const MERC_MAP_INTRO_CURVE = 1.42 // flyTo zoom-out arc (Mapbox default; higher = more dramatic)
 
 // App shell (MER-9) — bottom nav heights. Mirrors BlueFire's MobileBottomNavigationMenu shim:

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -26,5 +26,11 @@ import LandingPageCard from '@/components/navigation/LandingPageCard.vue'
 import { routes } from '@/schemas/routerLinksSchema'
 
 const missionStatement = ref('An attempt to improve everything; beginning with weather.')
-const cards = computed(() => routes.filter((l) => !l.hideInMainNav))
+const cards = computed(() =>
+  routes
+    .filter((l) => !l.hideInMainNav)
+    // Card order is driven by the route's `order` key; routes without one fall to the end in
+    // their schema position (stable sort).
+    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
+)
 </script>

--- a/src/pages/Merc.vue
+++ b/src/pages/Merc.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Merc app shell (MER-9). Full-bleed, mobile-first: top bar → stage (map/list + fly-outs) →
        bottom nav. BlueFire's chrome is hidden for this route (see App.vue); the Merc theme is
-       scoped here so it never leaks into BlueFire. UI state lives in mercShellStore. -->
+       scoped here so it never leaks into BlueFire. UI state lives in mercLayoutStore. -->
   <v-theme-provider theme="merc" with-background class="merc-shell">
     <merc-top-bar class="flex-shrink-0" />
 
@@ -12,13 +12,13 @@
       <merc-map-canvas class="fill-height" />
 
       <merc-view-toggle
-        @update:model-value="shell.setView"
-        :model-value="shell.view"
+        @update:model-value="mercLayoutStore.setView"
+        :model-value="mercLayoutStore.view"
         class="merc-shell__view-toggle position-absolute"
       />
 
       <v-sheet
-        v-if="shell.view === 'list'"
+        v-if="mercLayoutStore.view === 'list'"
         color="background"
         class="merc-shell__list position-absolute d-flex align-center justify-center"
       >
@@ -29,14 +29,14 @@
            TODO: MER-9: wire Capacitor hardware back to close an open sheet first (needs the
            @capacitor/app dep — deferred to the native-shim follow-up). -->
       <Transition name="merc-scrim">
-        <v-sheet v-if="shell.activeSheet" @click="shell.close" class="merc-shell__scrim position-absolute" />
+        <v-sheet v-if="mercLayoutStore.activeSheet" @click="mercLayoutStore.close" class="merc-shell__scrim position-absolute" />
       </Transition>
       <Transition name="merc-sheet">
-        <v-sheet v-if="shell.activeSheet" color="transparent" class="merc-shell__sheet position-absolute">
-          <merc-showings-sheet v-if="shell.activeSheet === 'showings'" @close="shell.close" />
-          <merc-post-showing-sheet v-else-if="shell.activeSheet === 'post'" @close="shell.close" />
-          <merc-wallet-sheet v-else-if="shell.activeSheet === 'wallet'" @close="shell.close" />
-          <merc-profile-sheet v-else-if="shell.activeSheet === 'me'" @close="shell.close" />
+        <v-sheet v-if="mercLayoutStore.activeSheet" color="transparent" class="merc-shell__sheet position-absolute">
+          <merc-showings-sheet v-if="mercLayoutStore.activeSheet === 'showings'" @close="mercLayoutStore.close" />
+          <merc-post-showing-sheet v-else-if="mercLayoutStore.activeSheet === 'post'" @close="mercLayoutStore.close" />
+          <merc-wallet-sheet v-else-if="mercLayoutStore.activeSheet === 'wallet'" @close="mercLayoutStore.close" />
+          <merc-profile-sheet v-else-if="mercLayoutStore.activeSheet === 'me'" @close="mercLayoutStore.close" />
         </v-sheet>
       </Transition>
     </v-sheet>
@@ -47,7 +47,7 @@
 
 <script setup>
 import { onMounted } from 'vue'
-import { useMercShellStore } from '@/stores/mercShellStore'
+import { useMercLayoutStore } from '@/stores/mercLayoutStore'
 import MercTopBar from '@/components/merc/MercTopBar.vue'
 import MercMapCanvas from '@/components/merc/MercMapCanvas.vue'
 import MercViewToggle from '@/components/merc/MercViewToggle.vue'
@@ -57,10 +57,10 @@ import MercPostShowingSheet from '@/components/merc/MercPostShowingSheet.vue'
 import MercWalletSheet from '@/components/merc/MercWalletSheet.vue'
 import MercProfileSheet from '@/components/merc/MercProfileSheet.vue'
 
-const shell = useMercShellStore()
+const mercLayoutStore = useMercLayoutStore()
 
 // Enter the shell on a clean slate (the store persists across navigations).
-onMounted(() => shell.close())
+onMounted(() => mercLayoutStore.close())
 </script>
 
 <style scoped>

--- a/src/pages/MercLandingPage.vue
+++ b/src/pages/MercLandingPage.vue
@@ -1,35 +1,29 @@
 <template>
   <v-row justify="center" class="px-2">
     <v-col cols="12" md="10" lg="8">
-      <!-- Brand + working-draft tag -->
-      <v-row align="center" class="mt-4 mb-2">
-        <v-col cols="auto" class="d-flex align-center">
-          <v-icon color="teal" size="32" class="mr-2">
-            mdi-map-marker-radius
-          </v-icon>
-          <span class="text-h5 font-weight-bold">Merc</span>
-          <v-chip size="x-small" color="info" variant="tonal" class="ml-3">
-            Working draft
-          </v-chip>
-        </v-col>
-      </v-row>
-
-      <!-- Headline -->
+      <!-- Headline (marketplace message) — floated down from the top bar with breathing room -->
       <v-row>
         <v-col cols="12">
           <h1 class="text-h4 text-md-h3 font-weight-bold mb-4">
-            A marketplace where realtors hand off live showings, and the payout handles itself.
+            Hand off a live showing. The payout handles itself.
           </h1>
           <p class="text-body-1 text-medium-emphasis">
-            Two-sided. Listers post a showing (from their listings or a dropped pin) and attach a
-            payout. Adjacent claimers browse open showings on a map, bid to take them, and get paid
-            out of escrow when the appointment is confirmed.
+            Post a showing — from your listings or a dropped pin — and attach a payout. Nearby agents
+            browse open showings on a map, bid to cover them, and get paid from escrow the moment the
+            appointment's confirmed.
           </p>
         </v-col>
       </v-row>
 
-      <!-- Enter the shell -->
-      <v-row class="mt-10 mb-10">
+      <!-- How a listing works -->
+      <v-row class="mt-8 mb-15">
+        <v-col cols="12">
+          <merc-listing-flow />
+        </v-col>
+      </v-row>
+
+      <!-- Enter the shell — below the message, where it was -->
+      <v-row class="mb-15">
         <v-col cols="12">
           <v-btn
             @click="enterMerc"
@@ -44,6 +38,8 @@
           </v-btn>
         </v-col>
       </v-row>
+
+
 
       <!-- Live activity ticker -->
       <v-row class="mb-5">
@@ -71,6 +67,7 @@
 <script setup>
 import { useRouter } from 'vue-router'
 import MercLiveTicker from '@/components/merc/MercLiveTicker.vue'
+import MercListingFlow from '@/components/merc/MercListingFlow.vue'
 import { MERC_LANDING_STATS } from '@/mocks/mockLandingFeed'
 import { MERC_BASE_PATH } from '@/configs/mercDefaults'
 

--- a/src/schemas/routerLinksSchema.js
+++ b/src/schemas/routerLinksSchema.js
@@ -74,15 +74,17 @@ export const routes = [
     chips: ['coming soon']
   },
   {
-    name: 'Merc Preview',
+    name: 'Merc',
     bottomNavName: 'Merc',
+    order: 1, // leads the landing-page card order (LandingPage sorts cards by `order`)
     path: '/merc',
     component: () => import('@/pages/MercLandingPage.vue'),
     icon: 'mdi-map-marker-radius',
     color: 'teal-darken-1',
     class: '',
     details: 'Real-estate showing coordination — map-based dispatch & coverage.',
-    chips: ['In development'],
+    chips: ['Alpha', 'Live'],
+    chipColor: '#3b82f6', // Merc brand blue (theme secondary) — Merc's status chips render blue
     showInMobileNav: true
   },
   {

--- a/src/stores/mercLayoutStore.js
+++ b/src/stores/mercLayoutStore.js
@@ -5,7 +5,7 @@ import { useStorage } from '@vueuse/core'
 // Merc app-shell UI state (MER-9): which fly-out is open and which background the stage shows.
 // The bottom nav and view toggle call these actions directly, so there's no action bubbling
 // through emits — one named home for the shell's interaction state.
-export const useMercShellStore = defineStore('mercShellStore', () => {
+export const useMercLayoutStore = defineStore('mercLayoutStore', () => {
   // null | 'showings' | 'post' | 'wallet' | 'me'
   const activeSheet = ref(null)
   // 'map' | 'list'

--- a/src/stores/mercShellStore.js
+++ b/src/stores/mercShellStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { useStorage } from '@vueuse/core'
 
 // Merc app-shell UI state (MER-9): which fly-out is open and which background the stage shows.
 // The bottom nav and view toggle call these actions directly, so there's no action bubbling
@@ -9,6 +10,19 @@ export const useMercShellStore = defineStore('mercShellStore', () => {
   const activeSheet = ref(null)
   // 'map' | 'list'
   const view = ref('map')
+
+  // First-load cinematic fly-to (MER-26). Two concerns, two storages:
+  //  - introEnabled: sticky user preference (Profile toggle) — persists across sessions (localStorage).
+  //  - introPlayedThisSession: one-shot guard so the swoop plays at most once per browser session.
+  // Both live here (not in MercMapCanvas) because the canvas remounts on every /merc/app entry, so a
+  // component-local flag would reset and replay every time.
+  const introEnabled = useStorage('merc:intro-fly-to-enabled', true)
+  const introPlayedThisSession = useStorage('merc:intro-fly-to-played', false, window.sessionStorage)
+  const shouldPlayIntro = computed(() => introEnabled.value && !introPlayedThisSession.value)
+
+  function markIntroPlayed() {
+    introPlayedThisSession.value = true
+  }
 
   // Which bottom-nav destination reads as active. 'post' and 'map' both leave Map highlighted.
   const navSelection = computed(() =>
@@ -32,5 +46,16 @@ export const useMercShellStore = defineStore('mercShellStore', () => {
     view.value = next
   }
 
-  return { activeSheet, view, navSelection, select, openPost, close, setView }
+  return {
+    activeSheet,
+    view,
+    navSelection,
+    select,
+    openPost,
+    close,
+    setView,
+    introEnabled,
+    shouldPlayIntro,
+    markIntroPlayed
+  }
 })

--- a/src/stores/mercShellStore.js
+++ b/src/stores/mercShellStore.js
@@ -11,18 +11,10 @@ export const useMercShellStore = defineStore('mercShellStore', () => {
   // 'map' | 'list'
   const view = ref('map')
 
-  // First-load cinematic fly-to (MER-26). Two concerns, two storages:
-  //  - introEnabled: sticky user preference (Profile toggle) — persists across sessions (localStorage).
-  //  - introPlayedThisSession: one-shot guard so the swoop plays at most once per browser session.
-  // Both live here (not in MercMapCanvas) because the canvas remounts on every /merc/app entry, so a
-  // component-local flag would reset and replay every time.
+  // First-load cinematic fly-to (MER-26). The swoop replays on every entry/refresh (by design —
+  // it's the wow moment), gated only by this sticky user preference (the Profile toggle). Lives in
+  // the store, not MercMapCanvas, so the toggle persists across the canvas's remounts. localStorage.
   const introEnabled = useStorage('merc:intro-fly-to-enabled', true)
-  const introPlayedThisSession = useStorage('merc:intro-fly-to-played', false, window.sessionStorage)
-  const shouldPlayIntro = computed(() => introEnabled.value && !introPlayedThisSession.value)
-
-  function markIntroPlayed() {
-    introPlayedThisSession.value = true
-  }
 
   // Which bottom-nav destination reads as active. 'post' and 'map' both leave Map highlighted.
   const navSelection = computed(() =>
@@ -54,8 +46,6 @@ export const useMercShellStore = defineStore('mercShellStore', () => {
     openPost,
     close,
     setView,
-    introEnabled,
-    shouldPlayIntro,
-    markIntroPlayed
+    introEnabled
   }
 })


### PR DESCRIPTION
Cinematic intro: on entering /merc/app the Mapbox map opens at a global view
and flies into the NOVA market. Plays on every entry/refresh, gated by an
"Intro animation" toggle on the Profile sheet (localStorage) and
prefers-reduced-motion; start zoom, duration, and curve live in mercDefaults.js.
Rename: mercShellStore -> mercLayoutStore (all imports updated, store
destructured by its full name) and App.vue's isMercShell -> isMercApp.
Landing (/): the Merc card now leads via an `order` key in routerLinksSchema,
drops the "Preview" suffix, and shows blue "Alpha"/"Live" status chips driven
by a chipColor schema key (LandingPageCard).
/merc splash: refreshed headline + subcopy, and a new MercListingFlow.vue —
a compact "How a listing works" strip (List -> Claim -> Profit) that stays
side-by-side on mobile with MDI icons.